### PR TITLE
Add EDITORS file and describe how to setup on Helix

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -1,0 +1,21 @@
+# Editors
+
+## Helix
+
+Folowing Helix's [languages](https://docs.helix-editor.com/languages.html) documentation, you can
+use nelua-lsp by adding an entry to the `language-server` table, and be sure that the
+`nelua-lsp` value is present on `language-servers` key of the nelua entry of the `language` array:
+
+Here's an example: 
+
+```toml
+[[language]]
+name = "nelua"
+# [...]
+language-servers = [ "nelua-lsp" ]
+
+[language-server.nelua-lsp]
+command = "nelua"
+args = ["-L", "path/to/nelua-lsp", "--script", "path/to/nelua-lsp/main.lua"]
+```
+

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ This is an early implementation of writing an LSP server the for [nelua](https:/
 ```sh
   nelua -L /path/to/nelua-lsp --script /path/to/nelua-lsp/main.lua
 ```
+
+Read [EDITORS.md](EDITORS.md) to see how to use it in your code editor.


### PR DESCRIPTION
This adds an `EDITORS` markdown file to describe how to setup the lsp on Helix, and add an entry for Helix editor.